### PR TITLE
Use official Elite Dangerous app ID

### DIFF
--- a/load.py
+++ b/load.py
@@ -23,7 +23,7 @@ import Tkinter as tk
 import myNotebook as nb
 from config import config
 
-CLIENT_ID = '386149818227097610'
+CLIENT_ID = '363413225578037248'
 
 VERSION = '1.1.0'
 


### PR DESCRIPTION
This gets rid of the confusing "EDMC Discord Presence" name and replaces it with "Elite Dangerous" while sidestepping the legal concerns raised in #1.